### PR TITLE
Scc 3079 Add test for incomplete patron record

### DIFF
--- a/checkEligibility.js
+++ b/checkEligibility.js
@@ -188,7 +188,7 @@ function checkEligibility (patronId) {
       getPatronHoldsCount(patronId)
     ])).then((checks) => {
       const [canPlaceTestHold, ptypeAllowsHolds, holdsCount] = checks
-      const eligible = canPlaceTestHold && ptypeAllowsHolds && patronRecordComplete(patronId)
+      const eligible = canPlaceTestHold && ptypeAllowsHolds && patronRecordComplete(patronInfo)
 
       logger.debug(`Result of checks is ${canPlaceTestHold} && ${ptypeAllowsHolds}`)
 

--- a/checkEligibility.js
+++ b/checkEligibility.js
@@ -67,7 +67,7 @@ async function getPatronHoldsCount (patronId) {
  */
 function identifyPatronIssues (info, holdsCount) {
   let issues
-  if (patronRecordHasNecessaryProps(info)) {
+  if (patronRecordComplete(info)) {
     issues = {
       expired: new Date(info.expirationDate) < new Date(),
       blocked: info.blockInfo.code !== '-', // will want to change this once we have a list of block codes
@@ -88,9 +88,9 @@ function identifyPatronIssues (info, holdsCount) {
   return issues
 }
 
-function patronRecordHasNecessaryProps (info) {
+function patronRecordComplete (info) {
   const necessaryProps = ['expirationDate', 'blockInfo', 'moneyOwed']
-  return necessaryProps.every(prop => Object.keys(info).includes(prop))
+  return necessaryProps.every(prop => Object.keys(info).includes(prop)) === true
 }
 
 function patronPtypeAllowsHolds (info) {
@@ -188,7 +188,7 @@ function checkEligibility (patronId) {
       getPatronHoldsCount(patronId)
     ])).then((checks) => {
       const [canPlaceTestHold, ptypeAllowsHolds, holdsCount] = checks
-      const eligible = canPlaceTestHold && ptypeAllowsHolds
+      const eligible = canPlaceTestHold && ptypeAllowsHolds && patronRecordComplete(patronId)
 
       logger.debug(`Result of checks is ${canPlaceTestHold} && ${ptypeAllowsHolds}`)
 

--- a/test/checkEligibility.test.js
+++ b/test/checkEligibility.test.js
@@ -173,6 +173,30 @@ describe('checkEligibility', function () {
           })
       })
     })
+
+    describe.only('incomplete patron record', function () {
+      before(function () {
+        // Stub the patron fetch:
+        sinon.stub(wrapper, 'get').callsFake(() => {
+          return {
+            'expirationDate': '2022-04-01',
+            'moneyOwed': 0.0
+          }
+        })
+      })
+
+      after(function () {
+        wrapper.get.restore()
+      })
+
+      it('responds with patronRecordIncomplete', function () {
+        return checkEligibility.checkEligibility(5459252)
+          .then((response) => {
+            expect(response).to.be.a('object')
+            expect(response.eligibility).to.eq(false)
+          })
+      })
+    })
   })
 
   describe('getPatronHoldsCount', function () {

--- a/test/checkEligibility.test.js
+++ b/test/checkEligibility.test.js
@@ -128,7 +128,6 @@ describe('checkEligibility', function () {
       before(function () {
         // Stub the patron fetch:
         sinon.stub(wrapper, 'get').callsFake(() => ({
-          'id': 5459252,
           'expirationDate': '2022-04-01',
           'patronType': 10,
           'blockInfo': { 'code': '-' },
@@ -154,7 +153,6 @@ describe('checkEligibility', function () {
         // Stub the patron fetch:
         sinon.stub(wrapper, 'get').callsFake(() => {
           return {
-            'id': 5459252,
             'expirationDate': '2022-04-01',
             'patronType': 120,
             'blockInfo': { 'code': '-' },

--- a/test/checkEligibility.test.js
+++ b/test/checkEligibility.test.js
@@ -174,7 +174,7 @@ describe('checkEligibility', function () {
       })
     })
 
-    describe.only('incomplete patron record', function () {
+    describe('incomplete patron record', function () {
       before(function () {
         // Stub the patron fetch:
         sinon.stub(wrapper, 'get').callsFake(() => {

--- a/test/checkEligibility.test.js
+++ b/test/checkEligibility.test.js
@@ -128,6 +128,7 @@ describe('checkEligibility', function () {
       before(function () {
         // Stub the patron fetch:
         sinon.stub(wrapper, 'get').callsFake(() => ({
+          'id': 5459252,
           'expirationDate': '2022-04-01',
           'patronType': 10,
           'blockInfo': { 'code': '-' },
@@ -153,6 +154,7 @@ describe('checkEligibility', function () {
         // Stub the patron fetch:
         sinon.stub(wrapper, 'get').callsFake(() => {
           return {
+            'id': 5459252,
             'expirationDate': '2022-04-01',
             'patronType': 120,
             'blockInfo': { 'code': '-' },


### PR DESCRIPTION
Wrote one test to ensure incomplete patron records are handled without erroring out. This also required adding an explicit check for record completeness as a part of eligibility, otherwise some tests were breaking. 