### PR TITLE
Reduce false alarms due to logging normal errors

### DIFF
--- a/checkEligibility.js
+++ b/checkEligibility.js
@@ -23,7 +23,9 @@ async function patronCanPlaceTestHold (patronId, attempt = 1) {
     if (patronHoldsPossible) {
       response = e.response.data
       return true
-    } else logger.error(e)
+    } else {
+      logger.debug(`Recieved error from sierra indicating patron holds are not possible for patron ${patronId}: ${JSON.stringify(e.response.data)}`)
+    }
   } finally {
     logger.debug(`Finished performing patronCanPlaceTestHold with ${patronHoldsPossible ? 'favorable' : 'unfavorable'} response`, response)
   }


### PR DESCRIPTION
The app attempts to place a hold on a non existant item to determine if
the card has issues. If the error received is anything other than the
most common expected error, the app logs the error out. Because the
error contains the phrase "Error", this is triggering our error alarms
any time the eligibility service encounters a patron with card issues.
This fix moves that logging into the debug log (and includes context).