### PR TITLE
Noref/fix patron can place test hold

### DIFF
--- a/checkEligibility.js
+++ b/checkEligibility.js
@@ -31,7 +31,8 @@ async function patronCanPlaceTestHold (patronId, firstAttempt = true) {
         return true
       }
     } else {
-      patronHoldsPossible = e.response.data.description === 'Bib record cannot be loaded'
+      const { description, name } = e.response.data
+      patronHoldsPossible = (description === 'Bib record cannot be loaded' && name === 'XCirc error')
       if (patronHoldsPossible) {
         response = e.response.data
         return true

--- a/checkEligibility.js
+++ b/checkEligibility.js
@@ -31,7 +31,7 @@ async function patronCanPlaceTestHold (patronId, firstAttempt = true) {
         return true
       }
     } else {
-      patronHoldsPossible = e.response.data.description === 'XCirc error : Bib record cannot be loaded'
+      patronHoldsPossible = e.response.data.description === 'Bib record cannot be loaded'
       if (patronHoldsPossible) {
         response = e.response.data
         return true

--- a/test/checkEligibility.test.js
+++ b/test/checkEligibility.test.js
@@ -115,7 +115,7 @@ describe('checkEligibility', function () {
   describe('checkEligibility', function () {
     before(function () {
       // Stub the test hold:
-      const testHoldErrorResponse = { response: { data: { description: 'XCirc error : Bib record cannot be loaded' } } }
+      const testHoldErrorResponse = { response: { data: { description: 'Bib record cannot be loaded' } } }
       sinon.stub(wrapper, 'post').throws(testHoldErrorResponse)
 
       // Stub login:
@@ -235,7 +235,7 @@ describe('checkEligibility', function () {
       expect(postRequest.callCount).to.eq(2)
     })
     it('should return true after one empty and one error we are looking for', async () => {
-      const testHoldErrorResponse = { response: { data: { description: 'XCirc error : Bib record cannot be loaded' } } }
+      const testHoldErrorResponse = { response: { data: { description: 'Bib record cannot be loaded' } } }
       postRequest = sinon.stub(wrapper, 'post').onCall(0).throws()
       postRequest.onCall(1).throws(testHoldErrorResponse)
 

--- a/test/checkEligibility.test.js
+++ b/test/checkEligibility.test.js
@@ -115,7 +115,7 @@ describe('checkEligibility', function () {
   describe('checkEligibility', function () {
     before(function () {
       // Stub the test hold:
-      const testHoldErrorResponse = { response: { data: { description: 'Bib record cannot be loaded' } } }
+      const testHoldErrorResponse = { response: { data: { description: 'Bib record cannot be loaded', name: 'XCirc error' } } }
       sinon.stub(wrapper, 'post').throws(testHoldErrorResponse)
 
       // Stub login:
@@ -235,7 +235,7 @@ describe('checkEligibility', function () {
       expect(postRequest.callCount).to.eq(2)
     })
     it('should return true after one empty and one error we are looking for', async () => {
-      const testHoldErrorResponse = { response: { data: { description: 'Bib record cannot be loaded' } } }
+      const testHoldErrorResponse = { response: { data: { description: 'Bib record cannot be loaded', name: 'XCirc error' } } }
       postRequest = sinon.stub(wrapper, 'post').onCall(0).throws()
       postRequest.onCall(1).throws(testHoldErrorResponse)
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,7 +40,7 @@ describe('Lambda index handler', function () {
       let body
       if (path.includes('1001006')) {
         body = {
-          response: { data: { description: 'Bib record cannot be loaded' } }
+          response: { data: { description: 'Bib record cannot be loaded', name: 'XCirc error' } }
         }
         throw body
       } else {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,7 +40,7 @@ describe('Lambda index handler', function () {
       let body
       if (path.includes('1001006')) {
         body = {
-          response: { data: { description: 'XCirc error : Bib record cannot be loaded' } }
+          response: { data: { description: 'Bib record cannot be loaded' } }
         }
         throw body
       } else {


### PR DESCRIPTION
Sierra has moved the 'XCirc error' part of their error message to a new `name` field, so we need to modify our check.