### PR TITLE
Add check that description is defined

### DIFF
--- a/checkEligibility.js
+++ b/checkEligibility.js
@@ -37,11 +37,12 @@ async function patronCanPlaceTestHold (patronId, firstAttempt = true) {
       // We are making this a little more flexible in case there are other similar variants, but
       // anything including "XCirc error" and "Bib record cannot be loaded" in the description should
       // be fine
-      patronHoldsPossible = (
+      patronHoldsPossible = description && (
         description.includes('Bib record cannot be loaded')
       ) && (
         name === 'XCirc error' || description.includes('XCirc error')
       )
+
 
       if (patronHoldsPossible) {
         response = e.response.data

--- a/checkEligibility.js
+++ b/checkEligibility.js
@@ -43,7 +43,6 @@ async function patronCanPlaceTestHold (patronId, firstAttempt = true) {
         name === 'XCirc error' || description.includes('XCirc error')
       )
 
-
       if (patronHoldsPossible) {
         response = e.response.data
         return true


### PR DESCRIPTION
- Adds a little check that `description` is defined. This addresses the situation where a patron id doesn't match any record, in which case `description` is undefined, causing `includes` to raise an error