### PR TITLE
Fix noisy alarms when passed empty patron id

### DIFF
--- a/checkEligibility.js
+++ b/checkEligibility.js
@@ -197,6 +197,9 @@ async function sierraLogin () {
  *   2. Does patron's ptype allow them to place holds?
  */
 function checkEligibility (patronId) {
+  if (patronId === undefined) {
+    throw new ParameterError('Could not get patron info for undefined patronId')
+  }
   let patronInfo = null
   return config()
     .then(sierraLogin)

--- a/test/checkEligibility.test.js
+++ b/test/checkEligibility.test.js
@@ -241,6 +241,13 @@ describe('checkEligibility', function () {
           })
       })
     })
+
+    describe('undefined patron id', function () {
+      it('responds with patronRecordIncomplete', function () {
+        return expect(() => checkEligibility.checkEligibility(undefined))
+          .to.throw('Could not get patron info for undefined patronId')
+      })
+    })
   })
 
   describe('getPatronHoldsCount', function () {


### PR DESCRIPTION
* Ticket: https://newyorkpubliclibrary.atlassian.net/browse/SCC-4971
* Should fix us logging errors when someone passes in an undefined patron id.